### PR TITLE
Perf gains

### DIFF
--- a/chkjson_test.go
+++ b/chkjson_test.go
@@ -143,7 +143,7 @@ func TestMost(t *testing.T) {
 }
 
 func BenchmarkValid(b *testing.B) {
-	in := []byte(`{"foo": 1, "bar": [{"first": 1, "second": 2, "last": 9999}, {}]}`)
+	in := []byte(`{"foo": 1, "bar": [{"fi\uabcdrst": 1,  "se\\cond": 2, "last": 9999}, {}]}`)
 	if !Valid(in) {
 		b.Fatal("benchmark JSON is not valid!")
 	}

--- a/compact_test.go
+++ b/compact_test.go
@@ -104,7 +104,7 @@ func TestCompact(t *testing.T) {
 }
 
 func BenchmarkCompact(b *testing.B) {
-	orig := []byte(`{"foo": 1, "bar": [{"first": 1, "second": 2, "last": 9999}, {}]}`)
+	orig := []byte(`{"foo": 1, "bar": [{"fi\uabcdrst": 1,  "se\\cond": 2, "last": 9999}, {}]}`)
 	a := make([]byte, 0, len(orig))
 	for i := 0; i < b.N; i++ {
 		AppendCompact(a[:0], orig)


### PR DESCRIPTION
I would have liked to hope that `p.done()`, after inlining, would eliminate the bounds check on `p.c()`. That does not seem to have been the case.

This inlines all `p.done()` checks that led to `p.c()` which leads to the majority of this speed boost.

Another chunk of speed boost came from adding a "fast path" `c <= ' '` check to `isSpace`. I initially thought that four conditionals could be pipelined, but it's still better to just have one conditional for the normal case.

Some other code is reorganized to be more condensed.

Compact no longer re-evaluates the beginning-quote index in `beginStrOrEmpty`.

I played around with removing all `p.done()` calls but what remains (all in number parsing) did not change the ns bench time on benchmarks.

```
name       old time/op  new time/op  delta
Valid-4     456ns ± 0%   325ns ± 0%  -28.68%  (p=0.000 n=9+9)
Compact-4   507ns ± 0%   398ns ± 0%  -21.50%  (p=0.000 n=7+10)
```