### PR TITLE
Speed up (again)

### DIFF
--- a/chkjson_test.go
+++ b/chkjson_test.go
@@ -28,6 +28,7 @@ func TestMost(t *testing.T) {
 		`"foo"`,
 		"\"\xe2\x80\xa8\xe2\x80\xa9\"", // line-sep and paragraph-sep
 		` "\uaaaa" `,
+		` "\uaaaa\uaaaa" `,
 		` "\`,
 		` "\z`,
 		" \"f\x00o\"",
@@ -67,7 +68,10 @@ func TestMost(t *testing.T) {
 		`{"foo": [{"":3, "4": "3"}, 4, {}], "t_wo": 1}`,
 		` {"foo": 2,"fudge}`,
 		`{{"foo": }}`,
+		`{"foo": true, f "a": true}`,
 		`{{"foo": [{"":3, 4: "3"}, 4, "5": {4}]}, "t_wo": 1}`,
+		`{"\uaaaa\uaaaa" : true}`,
+		"{\"\xe2\x80\xa8\xe2\x80\xa9\": true}", // line-sep and paragraph-sep
 		"{",
 		`{"foo"`,
 		`{"foo",f}`,
@@ -83,6 +87,7 @@ func TestMost(t *testing.T) {
 		`[`,
 		`[1,`,
 		`[1a`,
+		`[1a]`,
 		`[]]`,
 
 		// boolean

--- a/compact_test.go
+++ b/compact_test.go
@@ -28,7 +28,7 @@ func TestCompactSeparators(t *testing.T) {
 			}
 
 			if !bytes.Equal(gotOrig, []byte(test.in)) {
-				t.Errorf("AppendCompact: got %s != exp %s", gotOrig, test.in)
+				t.Errorf("AppendCompact: got %q != exp %q", gotOrig, test.in)
 			}
 
 			got, ok := AppendCompactJSONP(in[:0], in)
@@ -49,7 +49,7 @@ func TestCompactSeparators(t *testing.T) {
 			}
 
 			if !bytes.Equal(got, []byte(test.exp)) {
-				t.Errorf("got %s != exp %s", got, test.exp)
+				t.Errorf("got %q != exp %q", got, test.exp)
 			}
 		}
 	}


### PR DESCRIPTION
The first commit has technical details in the commit message. This change is a good boost (albeit at the expense some more of what remained of any code legibility); this validating code is now the fastest of any Go validators (nothing else really provides compacting).

```
name                  old time/op    new time/op    delta
Compact-4                255ns ± 1%     209ns ± 0%  -18.16%  (p=0.000 n=18+7)
ExtCompact/canada-4     6.70ms ± 0%    3.89ms ± 0%  -42.03%  (p=0.000 n=18+9)
ExtCompact/citm-4       4.07ms ± 0%    2.51ms ± 0%  -38.46%  (p=0.000 n=18+9)
ExtCompact/large-4      94.8µs ± 0%    73.0µs ± 1%  -23.01%  (p=0.000 n=17+10)
ExtCompact/medium-4     7.00µs ± 1%    5.44µs ± 1%  -22.24%  (p=0.000 n=17+10)
ExtCompact/small-4       549ns ± 2%     453ns ± 0%  -17.54%  (p=0.000 n=18+9)
ExtCompact/twitter-4    1.99ms ± 0%    1.53ms ± 1%  -23.28%  (p=0.000 n=18+9)
ExtValid/canada-4       5.14ms ± 0%    3.05ms ± 0%  -40.58%  (p=0.000 n=9+9)
ExtValid/citm-4         3.69ms ± 1%    2.30ms ± 2%  -37.63%  (p=0.000 n=9+10)
ExtValid/large-4        68.3µs ± 3%    43.1µs ± 0%  -36.88%  (p=0.000 n=10+8)
ExtValid/medium-4       5.38µs ± 0%    3.37µs ± 2%  -37.32%  (p=0.000 n=10+10)
ExtValid/small-4         419ns ± 1%     261ns ± 2%  -37.74%  (p=0.000 n=10+10)
ExtValid/twitter-4      1.63ms ± 0%    1.01ms ± 1%  -37.99%  (p=0.000 n=9+10)
Valid-4                  196ns ± 1%     137ns ± 0%  -30.14%  (p=0.000 n=10+7)

name                  old speed      new speed      delta
ExtCompact/canada-4    336MB/s ± 0%   579MB/s ± 0%  +72.49%  (p=0.000 n=18+9)
ExtCompact/citm-4      424MB/s ± 0%   689MB/s ± 0%  +62.50%  (p=0.000 n=18+9)
ExtCompact/large-4     296MB/s ± 0%   385MB/s ± 1%  +29.89%  (p=0.000 n=17+10)
ExtCompact/medium-4    333MB/s ± 0%   428MB/s ± 1%  +28.59%  (p=0.000 n=17+10)
ExtCompact/small-4     346MB/s ± 2%   419MB/s ± 0%  +21.25%  (p=0.000 n=18+9)
ExtCompact/twitter-4   318MB/s ± 0%   414MB/s ± 1%  +30.35%  (p=0.000 n=18+9)
ExtValid/canada-4      438MB/s ± 0%   737MB/s ± 0%  +68.31%  (p=0.000 n=9+9)
ExtValid/citm-4        468MB/s ± 1%   751MB/s ± 2%  +60.35%  (p=0.000 n=9+10)
ExtValid/large-4       412MB/s ± 3%   653MB/s ± 0%  +58.40%  (p=0.000 n=10+8)
ExtValid/medium-4      433MB/s ± 0%   691MB/s ± 2%  +59.53%  (p=0.000 n=10+10)
ExtValid/small-4       453MB/s ± 1%   729MB/s ± 1%  +60.82%  (p=0.000 n=10+9)
ExtValid/twitter-4     387MB/s ± 0%   624MB/s ± 1%  +61.26%  (p=0.000 n=9+10)
``