### PR TITLE
add Compact function and test for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ If you are streaming _lots_ of JSON _all of the time_, the CPU and memory
 savings this package provides add up.
 
 This package outperforms any other JSON validating or compacting
-implementations. The code, while _supremely_ ugly, is written for the compiler.
+implementations. The code, while _supremely_ ugly and repetitive,
+is written for the compiler.
 The implementation was guided by profiling sections of code individually with
 various implementations.
 
@@ -43,6 +44,9 @@ recurses when necessary and this consumes only about 2.2x the memory a simple
 all cases, this extra memory consumption is not an issue, especially so since
 the CPU is freed up more for actual important work.
 
+The implementation is extremely repetitive and ugly, making it difficult to
+maintain. This tradeoff was made due to ideally not ever _needing_ changes.
+
 If you are only validating or compacting a few (countable) amount of times,
 this package is overkill.
 
@@ -54,6 +58,8 @@ Full documentation can be found on [`godoc`](https://godoc.org/github.com/twmb/c
 
 What follows is `benchstat` output for JSON files taken from [valyala/fastjson](https://github.com/valyala/fastjson)
 comparing stdlib against my code.
+
+Memory allocation savings are elided for brevity (normally 72 to 312 bytes).
 
 ```
 name                  old time/op    new time/op    delta
@@ -83,32 +89,24 @@ ExtValid/large-4       184MB/s ± 0%   590MB/s ± 0%  +220.77%  (p=0.000 n=9+10)
 ExtValid/medium-4      187MB/s ± 0%   618MB/s ± 0%  +230.03%  (p=0.000 n=10+10)
 ExtValid/small-4       175MB/s ± 0%   618MB/s ± 0%  +254.06%  (p=0.000 n=10+10)
 ExtValid/twitter-4     191MB/s ± 0%   593MB/s ± 0%  +210.19%  (p=0.000 n=10+9)
+```
 
-name                  old alloc/op   new alloc/op   delta
-ExtCompact/canada-4       184B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
-ExtCompact/citm-4         184B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
-ExtCompact/large-4        184B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
-ExtCompact/medium-4       184B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
-ExtCompact/small-4       72.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
-ExtCompact/twitter-4      312B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
-ExtValid/canada-4         184B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
-ExtValid/citm-4           184B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
-ExtValid/large-4          184B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
-ExtValid/medium-4         184B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
-ExtValid/small-4         72.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
-ExtValid/twitter-4        312B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
+In place compacting directly using the `Compact` function is even faster.
 
-name                  old allocs/op  new allocs/op  delta
-ExtCompact/canada-4       5.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
-ExtCompact/citm-4         5.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
-ExtCompact/large-4        5.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
-ExtCompact/medium-4       5.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
-ExtCompact/small-4        2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
-ExtCompact/twitter-4      6.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
-ExtValid/canada-4         5.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
-ExtValid/citm-4           5.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
-ExtValid/large-4          5.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
-ExtValid/medium-4         5.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
-ExtValid/small-4          2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
-ExtValid/twitter-4        6.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
+```
+name                         old time/op    new time/op    delta
+ExtCompactInplace/canada-4     16.8ms ± 0%     3.5ms ± 1%    -78.88%  (p=0.000 n=8+10)
+ExtCompactInplace/citm-4       13.9ms ± 1%     0.9ms ± 1%    -93.36%  (p=0.000 n=10+10)
+ExtCompactInplace/large-4       235µs ± 1%      56µs ± 1%    -76.35%  (p=0.000 n=10+10)
+ExtCompactInplace/medium-4     21.1µs ± 1%     3.2µs ± 1%    -84.73%  (p=0.000 n=10+10)
+ExtCompactInplace/small-4      1.85µs ± 3%    0.28µs ± 2%    -84.83%  (p=0.000 n=10+10)
+ExtCompactInplace/twitter-4    5.35ms ± 0%    0.88ms ± 1%    -83.58%  (p=0.000 n=10+10)
+
+name                         old speed      new speed      delta
+ExtCompactInplace/canada-4    134MB/s ± 0%   636MB/s ± 1%   +373.47%  (p=0.000 n=8+10)
+ExtCompactInplace/citm-4      124MB/s ± 1%  1872MB/s ± 1%  +1406.08%  (p=0.000 n=10+10)
+ExtCompactInplace/large-4     120MB/s ± 1%   506MB/s ± 1%   +322.89%  (p=0.000 n=10+10)
+ExtCompactInplace/medium-4    110MB/s ± 1%   723MB/s ± 0%   +554.90%  (p=0.000 n=10+10)
+ExtCompactInplace/small-4     103MB/s ± 3%   677MB/s ± 2%   +558.42%  (p=0.000 n=10+10)
+ExtCompactInplace/twitter-4   118MB/s ± 0%   719MB/s ± 1%   +508.94%  (p=0.000 n=10+10)
 ```

--- a/chkjson.go
+++ b/chkjson.go
@@ -14,6 +14,10 @@
 // library's AppendCompact is usually around 3x-4x faster than encoding/json's
 // Compact.
 //
+// For compacting JSON in place with no regard to JSONP, this library provides
+// a direct Compact function that is faster and more intuitive than using
+// AppendCompact to compact in place.
+//
 // In essence, this library aims to provide faster and allocation free
 // alternatives to encoding/json for a few specific use cases. For use cases
 // and design considerations, visit this project's repo's README.

--- a/compact.go
+++ b/compact.go
@@ -18,6 +18,8 @@ import (
 // This function does not escape line-separator or paragraph-separator
 // characters, which can be problematic for JSONP. If conversion is necessary,
 // use AppendCompactJSONP.
+//
+// If simply compacting a slice in place, it is recommended to use Compact.
 func AppendCompact(dst, src []byte) ([]byte, bool) {
 	return AppendCompactString(dst, *(*string)(unsafe.Pointer(&src)))
 }
@@ -106,9 +108,9 @@ whitespace:
 	case 't':
 		end := at + len("rue")
 		if end <= len(src) &&
+			src[at+2] == 'e' &&
 			src[at] == 'r' &&
-			src[at+1] == 'u' &&
-			src[at+2] == 'e' {
+			src[at+1] == 'u' {
 			dst = append(dst, 't', 'r', 'u', 'e')
 			return dst, end, true
 		}

--- a/compact_inplace.go
+++ b/compact_inplace.go
@@ -1,0 +1,322 @@
+package chkjson
+
+// Compact compacts a slice in place and returns the updated slice and if the
+// slice was valid JSON. If it was invliad, this returns nil.
+//
+// This is similar to AppendCompact(b[:0], b), but is faster and more intuitive.
+//
+// This function purely compacts; it does nothing about JSONP separators.
+func Compact(b []byte) ([]byte, bool) {
+	w, r, ok := compact(b, 0, 0)
+	if !ok {
+		return nil, false
+	}
+
+	for ; r < len(b); r++ {
+		switch b[r] {
+		case '\t', '\n', '\r', ' ':
+		default:
+			return nil, false
+		}
+	}
+	return b[:w], true
+}
+
+func compact(b []byte, w, r int) (int, int, bool) {
+	rstart := r
+	var c byte
+	var ok bool
+
+whitespace:
+	if r == len(b) {
+		return 0, 0, false
+	}
+
+	switch c, r = b[r], r+1; c {
+	case ' ', '\r', '\t', '\n':
+		rstart++
+		goto whitespace
+	case '{':
+		b[w], w = '{', w+1
+		rstart++
+		goto finObj
+	case '[':
+		b[w], w = '[', w+1
+		rstart++
+		goto finArr
+	case '"':
+		goto finStr
+	case 't':
+		end := r + len("rue")
+		if end <= len(b) &&
+			b[r+2] == 'e' &&
+			b[r+1] == 'u' &&
+			b[r] == 'r' {
+			b[w+3], b[w+2], b[w+1], b[w] = 'e', 'u', 'r', 't'
+			return w + 4, r + 3, true
+		}
+		return 0, 0, false
+	case 'f':
+		end := r + len("alse")
+		if end <= len(b) &&
+			b[r+3] == 'e' &&
+			b[r+2] == 's' &&
+			b[r+1] == 'l' &&
+			b[r] == 'a' {
+			b[w+4], b[w+3], b[w+2], b[w+1], b[w] = 'e', 's', 'l', 'a', 'f'
+			return w + 5, r + 4, true
+		}
+		return 0, 0, false
+	case 'n':
+		end := r + len("ull")
+		if end <= len(b) &&
+			b[r+2] == 'l' &&
+			b[r+1] == 'l' &&
+			b[r] == 'u' {
+			b[w+3], b[w+2], b[w+1], b[w] = 'l', 'l', 'u', 'n'
+			return w + 4, r + 3, true
+		}
+		return 0, 0, false
+	case '-':
+		goto finNeg
+	case '0':
+		goto fin0
+	case '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		goto fin1
+	default:
+		return 0, 0, false
+	}
+
+finStr:
+	for ; r < len(b); r++ {
+		switch b[r] {
+		default:
+		case 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+			10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+			20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+			30, 31:
+			return 0, 0, false
+		case '"':
+			r++
+			w += copy(b[w:], b[rstart:r])
+			return w, r, true
+		case '\\':
+			r++
+			if r == len(b) {
+				return 0, 0, false
+			}
+			switch b[r] {
+			case 'b', 'f', 'n', 'r', 't', '\\', '/', '"':
+			case 'u':
+				if len(b[r:]) > 5 &&
+					isHex(b[r+4]) &&
+					isHex(b[r+3]) &&
+					isHex(b[r+2]) &&
+					isHex(b[r+1]) {
+					r += 5
+					goto finStr
+				}
+				return 0, 0, false
+			default:
+				return 0, 0, false
+			}
+		}
+	}
+	return 0, 0, false
+
+finObj:
+	for r < len(b) { // finish obj immediately or begin a key
+		switch c, r = b[r], r+1; c {
+		case ' ', '\r', '\t', '\n':
+			rstart++
+		case '"':
+			goto finObjKey
+		case '}':
+			b[w] = '}'
+			return w + 1, r, true
+		default:
+			return 0, 0, false
+		}
+	}
+
+finObjKey:
+	for ; r < len(b); r++ { // duplicated above for better jumps
+		switch b[r] {
+		default:
+		case 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+			10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+			20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+			30, 31:
+			return 0, 0, false
+		case '"':
+			r++
+			w += copy(b[w:], b[rstart:r])
+			goto finObjSep
+		case '\\':
+			r++
+			if r == len(b) {
+				return 0, 0, false
+			}
+			switch b[r] {
+			case 'b', 'f', 'n', 'r', 't', '\\', '/', '"':
+			case 'u':
+				if len(b[r:]) > 5 &&
+					isHex(b[r+4]) &&
+					isHex(b[r+3]) &&
+					isHex(b[r+2]) &&
+					isHex(b[r+1]) {
+					r += 5
+					goto finObjKey
+				}
+				return 0, 0, false
+			default:
+				return 0, 0, false
+			}
+		}
+	}
+	return 0, 0, false
+
+finObjSep:
+	for r < len(b) {
+		switch c, r = b[r], r+1; c {
+		case ' ', '\r', '\t', '\n':
+		case ':':
+			b[w], w = ':', w+1
+			goto objAny
+		default:
+			return 0, 0, false
+		}
+	}
+
+objAny:
+	if w, r, ok = compact(b, w, r); !ok {
+		return 0, 0, false
+	}
+
+	for r < len(b) {
+		switch c, r = b[r], r+1; c {
+		case ' ', '\r', '\t', '\n':
+		case ',':
+			b[w], w, rstart = ',', w+1, r-1
+			goto beginStr
+		case '}':
+			b[w] = '}'
+			return w + 1, r, true
+		default:
+			return 0, 0, false
+		}
+	}
+
+beginStr:
+	for r < len(b) {
+		switch c, r = b[r], r+1; c {
+		case ' ', '\r', '\t', '\n':
+		case '"':
+			rstart = r - 1
+			goto finObjKey
+		default:
+			return 0, 0, false
+		}
+	}
+	return 0, 0, false
+
+finArr:
+	for r < len(b) {
+		switch c = b[r]; c {
+		case ' ', '\r', '\t', '\n':
+			r++
+		case ']':
+			b[w] = ']'
+			return w + 1, r + 1, true
+		default:
+			goto arrAny
+		}
+	}
+
+arrAny:
+	if w, r, ok = compact(b, w, r); !ok {
+		return 0, 0, false
+	}
+
+	for r < len(b) {
+		switch c, r = b[r], r+1; c {
+		case ' ', '\r', '\t', '\n':
+		case ',':
+			b[w], w = ',', w+1
+			goto arrAny
+		case ']':
+			b[w] = ']'
+			return w + 1, r, true
+		default:
+			return 0, 0, false
+		}
+	}
+
+	return 0, 0, false
+
+finNeg:
+	if r == len(b) {
+		return 0, 0, false
+	}
+	if c, r = b[r], r+1; c == '0' {
+		goto fin0
+	}
+	if !isNat(c) {
+		return 0, 0, false
+	}
+
+fin1:
+	for ; r < len(b) && isNum(b[r]); r++ {
+	}
+
+fin0:
+	if r == len(b) {
+		w += copy(b[w:], b[rstart:r])
+		return w, r, true
+	}
+	c = b[r]
+	if isE(c) {
+		r++
+		goto finE
+	}
+	if c != '.' {
+		w += copy(b[w:], b[rstart:r])
+		return w, r, true
+	}
+	r++
+
+	// finDot
+	if r == len(b) {
+		return 0, 0, false
+	}
+	if c, r = b[r], r+1; !isNum(c) { // first char after dot must be num
+		return 0, 0, false
+	}
+
+	for ; r < len(b) && isNum(b[r]); r++ {
+	}
+
+	if r == len(b) || !isE(b[r]) {
+		w += copy(b[w:], b[rstart:r])
+		return w, r, true
+	}
+	r++
+
+finE:
+	if r == len(b) {
+		return 0, 0, false
+	}
+	if c, r = b[r], r+1; c == '+' || c == '-' {
+		if r == len(b) {
+			return 0, 0, false
+		}
+		c, r = b[r], r+1
+	}
+	if !isNum(c) { // first after e (and +/-) must be num
+		return 0, 0, false
+	}
+	for ; r < len(b) && isNum(b[r]); r++ {
+	}
+	w += copy(b[w:], b[rstart:r])
+	return w, r, true
+}

--- a/ext_test.go
+++ b/ext_test.go
@@ -86,6 +86,20 @@ func BenchmarkExtCompact(b *testing.B) {
 	}
 }
 
+func BenchmarkExtCompactInplace(b *testing.B) {
+	for fname, bs := range extFiles {
+		b.Run(fname, func(b *testing.B) {
+			buf, _ := AppendCompact(nil, bs)
+			b.ReportAllocs()
+			b.SetBytes(int64(len(bs)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				Compact(buf)
+			}
+		})
+	}
+}
+
 /* if you are curious for comparison, uncomment below.
 func BenchmarkExtValidStdlib(b *testing.B) {
 	for fname, bs := range extFiles {

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/twmb/chkjson
+
+go 1.11


### PR DESCRIPTION
The code here is getting a bit redundant, yes, but Compact is a slightly
stripped down version of AppendCompact.

The two main benefits of a direct in place compacting function are
1) faster
2) ready for an assembly implementation

Other changes in this commit:
- go.mod specifies we can support 1.11
  - meaning 1.12 will stop rewriting the file to contain 1.12
- TestMost has been changed to use subtests
  - makes testing specific cases way easier (-run TestMost/11)
- adds Ext benchmarks for this new in place compacting
- adds tests for the new compacting
- adds relevant fuzzing for Compact
  - ran this for 20+ minutes across three runs; first two runs had
    bugs in the test, final run of 8m showed nothing

Compared to the current way of compacting inplace:

```
ExtCompact/canada-4     4.04ms ± 1%    3.54ms ± 1%   -12.29%  (p=0.000 n=10+10)
ExtCompact/citm-4       2.57ms ± 0%    0.92ms ± 1%   -64.05%  (p=0.000 n=8+10)
ExtCompact/large-4      70.2µs ± 1%    55.5µs ± 1%   -20.95%  (p=0.000 n=10+10)
ExtCompact/medium-4     5.22µs ± 2%    3.22µs ± 1%   -38.34%  (p=0.000 n=10+10)
ExtCompact/small-4       451ns ± 1%     280ns ± 2%   -37.84%  (p=0.000 n=10+10)
ExtCompact/twitter-4    1.43ms ± 0%    0.88ms ± 1%   -38.63%  (p=0.000 n=10+10)

name                  old speed      new speed      delta
ExtCompact/canada-4    558MB/s ± 1%   636MB/s ± 1%   +14.01%  (p=0.000 n=10+10)
ExtCompact/citm-4      673MB/s ± 0%  1872MB/s ± 1%  +178.20%  (p=0.000 n=8+10)
ExtCompact/large-4     400MB/s ± 1%   506MB/s ± 1%   +26.50%  (p=0.000 n=10+10)
ExtCompact/medium-4    446MB/s ± 1%   723MB/s ± 0%   +62.16%  (p=0.000 n=10+10)
ExtCompact/small-4     421MB/s ± 1%   677MB/s ± 2%   +60.87%  (p=0.000 n=10+10)
ExtCompact/twitter-4   441MB/s ± 0%   719MB/s ± 1%   +62.96%  (p=0.000 n=10+10)
```

This updates the README to add Compact benchmarks against the stdlib and
to remove memory benchmarks (mostly a waste of space).

The package documentation has a minor update as well.